### PR TITLE
Chomp firebase_cli_path parameter

### DIFF
--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -9,15 +9,14 @@ require_relative '../helper/firebase_app_distribution_helper'
 module Fastlane
   module Actions
     class FirebaseAppDistributionAction < Action
-      DEFAULT_FIREBASE_CLI_PATH = `which firebase`.chomp
+      DEFAULT_FIREBASE_CLI_PATH = `which firebase`
       FIREBASECMD_ACTION = "appdistribution:distribute".freeze
 
       extend Helper::FirebaseAppDistributionHelper
 
       def self.run(params)
         params.values # to validate all inputs before looking for the ipa/apk
-
-        cmd = [params[:firebase_cli_path], FIREBASECMD_ACTION]
+        cmd = [params[:firebase_cli_path].chomp, FIREBASECMD_ACTION]
         cmd << Shellwords.escape(params[:ipa_path] || params[:apk_path])
         cmd << "--app #{params[:app]}"
 
@@ -93,6 +92,8 @@ module Fastlane
                                        optional: false,
                                        type: String,
                                        verify_block: proc do |value|
+                                         # value is chomped
+                                         value.chomp!
                                          if value.to_s == "" || !File.exist?(value)
                                            UI.user_error!("firebase_cli_path: missing path to firebase cli tool. Please install firebase in $PATH or specify path")
                                          end

--- a/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
+++ b/lib/fastlane/plugin/firebase_app_distribution/actions/firebase_app_distribution_action.rb
@@ -92,7 +92,6 @@ module Fastlane
                                        optional: false,
                                        type: String,
                                        verify_block: proc do |value|
-                                         # value is chomped
                                          value.chomp!
                                          if value.to_s == "" || !File.exist?(value)
                                            UI.user_error!("firebase_cli_path: missing path to firebase cli tool. Please install firebase in $PATH or specify path")

--- a/spec/firebase_app_distribution_action_spec.rb
+++ b/spec/firebase_app_distribution_action_spec.rb
@@ -19,6 +19,18 @@ describe Fastlane::Actions::FirebaseAppDistributionAction do
       }
       Fastlane::Actions::FirebaseAppDistributionAction.run(params)
     end
+
+    it 'removes trailing newlines from firebase_cli_path' do
+      expect(Fastlane::Actions).to receive(:sh_control_output).with("/tmp/fake-firebase-cli appdistribution:distribute /tmp/FakeApp.ipa --app abc:123 --testers-file /tmp/testers.txt --release-notes-file /tmp/release_notes.txt", { print_command: false, print_command_output: true })
+      params = {
+          app: "abc:123",
+          ipa_path: "/tmp/FakeApp.ipa",
+          firebase_cli_path: "/tmp/fake-firebase-cli\n",
+          testers_file: "/tmp/testers.txt",
+          release_notes_file: "/tmp/release_notes.txt"
+      }
+      Fastlane::Actions::FirebaseAppDistributionAction.run(params)
+    end
   end
 
   describe "flag helpers" do


### PR DESCRIPTION
Users may set the firebase_cli_path parameter via `which firebase` (as seen in https://github.com/fastlane-community/fastlane-plugin-firebase_app_distribution/issues/4), so we should chomp the input value as well.